### PR TITLE
fix flaky test br.com.helpdev.quaklog.entity.GameTest#shouldBuildGameWithSuccess

### DIFF
--- a/core/src/main/java/br/com/helpdev/quaklog/entity/Game.java
+++ b/core/src/main/java/br/com/helpdev/quaklog/entity/Game.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @Getter
 public class Game extends Notifiable {
@@ -24,7 +26,8 @@ public class Game extends Notifiable {
     private final GameTime endGameTime;
 
     private Game(final GameBuilder builder) {
-        this.players = List.copyOf(builder.players.values());
+        this.players = List.copyOf(builder.players.values().stream().sorted(
+            Comparator.comparing(PlayerInGame::getId)).collect(Collectors.toList()));
         this.gameParameters = Collections.unmodifiableMap(builder.gameParameters);
         this.totalKills = builder.totalKills.get();
         this.startGameTime = builder.startGameTime;


### PR DESCRIPTION
## Problem

The test `test br.com.helpdev.quaklog.entity.GameTest#shouldBuildGameWithSuccess` asserts the players which are stored in the game. These are stored in a List. The list is generated by the builder using a map. But the order, in which the players are returned by the map, is not deterministic, but the test expects the values to be in certain order. 
This leads to a flaky test. 

```shell
br.com.helpdev.quaklog.entity.GameTest > shouldBuildGameWithSuccess() FAILED
    org.opentest4j.AssertionFailedError: expected: <Mock for PlayerInGame, hashCode: 461659368> but was: <Mock for PlayerInGame, hashCode: 1532150109>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:56)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:186)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:181)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:500)
        at br.com.helpdev.quaklog.entity.GameTest.shouldBuildGameWithSuccess(GameTest.java:39)
```

https://github.com/gbzarelli/quaklog-api/blob/f651f2aa8e319375b5caf4f0fdf9abbba32bdc4c/core/src/test/java/br/com/helpdev/quaklog/entity/GameTest.java#L38-L39

https://github.com/gbzarelli/quaklog-api/blob/f651f2aa8e319375b5caf4f0fdf9abbba32bdc4c/core/src/main/java/br/com/helpdev/quaklog/entity/Game.java#L27


This problem was found by the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Engine.

## Solution
Sort the stream of players in the map by their ID, to make sure, they are returned in predefined order. 

https://github.com/gbzarelli/quaklog-api/blob/b76c1484d86032458d7af693a1242f03e99bfb3b/core/src/main/java/br/com/helpdev/quaklog/entity/Game.java#L29-L30


## Reproduce
To reproduce, follow the steps:

1. `./gradlew build -x test`
2. Add the following text to the top of the build.gradle file in $PROJ_DIR.
```shell
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
``` 
3. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
apply plugin: 'edu.illinois.nondex'
``` 
4. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```
5. Change the following lines
```shell
test {
  useJUnitPlatform()
}
// Change above to below
tasks.withType(Test) {
  useJUnitPlatform()
}
```
4. Run
```shell
./gradlew --info nondexTest --tests=br.com.helpdev.quaklog.entity.GameTest.shouldBuildGameWithSuccess --nondexRuns=100 -p core
``` 